### PR TITLE
Add turn to API request

### DIFF
--- a/src/chess.gleam
+++ b/src/chess.gleam
@@ -272,6 +272,13 @@ fn api_move(game: ChessGame, url: String) {
     url <> "/move",
     json.object([
       #("fen", json.string(fen(game))),
+      #("turn", {
+        let side = case side_to_move_ffi(game) {
+          "w" -> "white"
+          _ -> "black"
+        }
+        json.string(side)
+      }),
       #("failed_moves", json.array([], json.string)),
     ]),
     lustre_http.expect_text(ApiReturnedMove),


### PR DESCRIPTION
Wouldn't work on my bot until I added this, since it's part of the format specified in the templates.